### PR TITLE
feat: Adiciona endpoints para gerenciamento de Etiquetas e associação com Tarefas

### DIFF
--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaInsertRequestDTO.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaInsertRequestDTO.java
@@ -1,0 +1,13 @@
+package com.dev.gabriellucas.taskify.DTO;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class EtiquetaInsertRequestDTO {
+
+    private Long idEtiqueta;
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaRequestDTO.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaRequestDTO.java
@@ -1,0 +1,24 @@
+package com.dev.gabriellucas.taskify.DTO;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class EtiquetaRequestDTO {
+
+    private Long id;
+
+    @NotNull(message = "Não pode ser vazio.")
+    @Size(min = 2, max = 30, message = "O Nome deve ter entre 2 a 30 caracteres.")
+    private String nome;
+
+    @NotNull(message = "Não pode ser vazio.")
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6})$", message = "Cor deve estar no formato hexadecimal (#RRGGBB).")
+    private String cor;
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaRequestPatchDTO.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaRequestPatchDTO.java
@@ -1,0 +1,20 @@
+package com.dev.gabriellucas.taskify.DTO;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class EtiquetaRequestPatchDTO {
+
+    @Size(min = 2, max = 30, message = "O Nome deve ter entre 2 a 30 caracteres.")
+    private String nome;
+
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6})$", message = "Cor deve estar no formato hexadecimal (#RRGGBB).")
+    private String cor;
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaResponseDTO.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/EtiquetaResponseDTO.java
@@ -1,0 +1,15 @@
+package com.dev.gabriellucas.taskify.DTO;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class EtiquetaResponseDTO {
+
+    private Long id;
+    private String nome;
+    private String cor;
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/EtiquetaController.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/EtiquetaController.java
@@ -1,0 +1,54 @@
+package com.dev.gabriellucas.taskify.controllers;
+
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestPatchDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaResponseDTO;
+import com.dev.gabriellucas.taskify.services.EtiquetaService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping(value = "/api/etiquetas")
+@RequiredArgsConstructor
+public class EtiquetaController {
+
+    private final EtiquetaService service;
+
+    @PostMapping
+    public ResponseEntity<EtiquetaResponseDTO> saveEtiqueta(@Valid @RequestBody EtiquetaRequestDTO request) {
+        EtiquetaResponseDTO objDto = service.saveEtiqueta(request);
+        return ResponseEntity.created(ServletUriComponentsBuilder
+                        .fromCurrentRequest()
+                        .path("/{id}")
+                        .buildAndExpand(objDto.getId())
+                        .toUri())
+                .body(objDto);
+    }
+
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<EtiquetaResponseDTO> findEtiquetaById(@PathVariable Long id) {
+        EtiquetaResponseDTO response = service.findEtiquetaById(id);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PutMapping(value = "/{id}")
+    public ResponseEntity<EtiquetaResponseDTO> updateEtiqueta(@PathVariable Long id, @Valid @RequestBody EtiquetaRequestDTO request ) {
+        EtiquetaResponseDTO response = service.updateEtiqueta(id, request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> deleteEtiqueta(@PathVariable Long id) {
+        service.deleteEtiqueta(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping(value = "/{id}")
+    public ResponseEntity<EtiquetaResponseDTO> updateEtiquetaParcial(@PathVariable Long id, @Valid @RequestBody EtiquetaRequestPatchDTO request) {
+        EtiquetaResponseDTO responseDTO = service.updateEtiquetaParcial(id, request);
+        return  ResponseEntity.ok().body(responseDTO);
+    }
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
@@ -73,5 +73,19 @@ public class TarefaController {
         return ResponseEntity.ok().body(historicos);
     }
 
+    @PostMapping("/{id}/etiquetas")
+    public ResponseEntity<Void> addEtiquetasToTarefa(
+            @PathVariable Long id,
+            @RequestBody List<EtiquetaInsertRequestDTO> etiquetas) {
+        service.addEtiquetaToTarefa(id, etiquetas);
+        return ResponseEntity.ok().build();
+    }
 
+    @DeleteMapping("/{idTarefa}/etiquetas/{idEtiqueta}")
+    public ResponseEntity<Void> removeEtiquetaFromTarefa(
+            @PathVariable Long idTarefa,
+            @PathVariable Long idEtiqueta) {
+        service.removeEtiquetaFromTarefa(idTarefa, idEtiqueta);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/mappers/EtiquetaMapper.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/mappers/EtiquetaMapper.java
@@ -1,0 +1,22 @@
+package com.dev.gabriellucas.taskify.mappers;
+
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaResponseDTO;
+import com.dev.gabriellucas.taskify.entities.Etiqueta;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring")
+public interface EtiquetaMapper {
+
+    Etiqueta toEntity(EtiquetaRequestDTO request);
+
+    @Named("toDTO")
+    EtiquetaResponseDTO toDto(Etiqueta etiqueta);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntityFromDTO(EtiquetaRequestDTO requestDTO, @MappingTarget Etiqueta etiqueta);
+
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/EtiquetaRepository.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/EtiquetaRepository.java
@@ -1,0 +1,16 @@
+package com.dev.gabriellucas.taskify.repositories;
+
+import com.dev.gabriellucas.taskify.entities.Etiqueta;
+import com.dev.gabriellucas.taskify.entities.Tarefa;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EtiquetaRepository extends JpaRepository<Etiqueta, Long> {
+    @Query("SELECT COUNT(e) > 0 FROM Etiqueta e WHERE LOWER(e.nome) = LOWER(:nome) AND :tarefa MEMBER OF e.tarefas AND e.id != :id")
+    boolean existsEtiquetaWithNomeInTarefa(@Param("nome") String nome, @Param("tarefa") Tarefa tarefa, @Param("id") Long id);
+    @Query("SELECT COUNT(e) FROM Etiqueta e")
+    int countEtiquetas();
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/TarefaRepository.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/TarefaRepository.java
@@ -2,8 +2,14 @@ package com.dev.gabriellucas.taskify.repositories;
 
 import com.dev.gabriellucas.taskify.entities.Tarefa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface TarefaRepository extends JpaRepository<Tarefa, Long> {
+    @Query("SELECT COUNT(t) FROM Tarefa t WHERE t.lista.id = :id")
+    int countTarefasByListaId(@Param("id") Long id);
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/EtiquetaService.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/EtiquetaService.java
@@ -1,0 +1,15 @@
+package com.dev.gabriellucas.taskify.services;
+
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestPatchDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaResponseDTO;
+
+public interface EtiquetaService {
+
+    EtiquetaResponseDTO saveEtiqueta(EtiquetaRequestDTO request);
+    EtiquetaResponseDTO findEtiquetaById(Long id);
+    EtiquetaResponseDTO updateEtiqueta(Long id, EtiquetaRequestDTO request);
+    void deleteEtiqueta(Long id);
+    EtiquetaResponseDTO updateEtiquetaParcial(Long id, EtiquetaRequestPatchDTO request);
+
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/TarefaService.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/TarefaService.java
@@ -14,4 +14,6 @@ public interface TarefaService {
     List<ComentarioResponseDTO> findAllCommentsByTarefaId(Long id);
     List<AnexoResponseDTO> findAllAnexosByTarefaId(Long id);
     List<HistoricoResponseDTO> findAllHistoricosByTarefaId(Long id);
+    void addEtiquetaToTarefa(Long idTarefa, List<EtiquetaInsertRequestDTO> request);
+    void removeEtiquetaFromTarefa(Long idTarefa, Long idEtiqueta);
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/EtiquetaServiceImpl.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/EtiquetaServiceImpl.java
@@ -1,0 +1,100 @@
+package com.dev.gabriellucas.taskify.services.impl;
+
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaRequestPatchDTO;
+import com.dev.gabriellucas.taskify.DTO.EtiquetaResponseDTO;
+import com.dev.gabriellucas.taskify.entities.Etiqueta;
+import com.dev.gabriellucas.taskify.entities.Tarefa;
+import com.dev.gabriellucas.taskify.exceptions.BusinessException;
+import com.dev.gabriellucas.taskify.exceptions.ResourceNotFoundException;
+import com.dev.gabriellucas.taskify.mappers.EtiquetaMapper;
+import com.dev.gabriellucas.taskify.repositories.EtiquetaRepository;
+import com.dev.gabriellucas.taskify.services.EtiquetaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EtiquetaServiceImpl implements EtiquetaService {
+
+    private final EtiquetaMapper mapper;
+    private final EtiquetaRepository repository;
+
+    @Override
+    @Transactional
+    public EtiquetaResponseDTO saveEtiqueta(EtiquetaRequestDTO request) {
+        maxEtiquetas();
+        Etiqueta etiqueta = mapper.toEntity(request);
+        return mapper.toDto(repository.save(etiqueta));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public EtiquetaResponseDTO findEtiquetaById(Long id) {
+        Optional<Etiqueta> obj = repository.findById(id);
+        Etiqueta entity = obj.orElseThrow(() -> new ResourceNotFoundException("Etiqueta não encontrada, ID:" + id));
+        return mapper.toDto(entity);
+    }
+
+    @Override
+    @Transactional
+    public EtiquetaResponseDTO updateEtiqueta(Long id, EtiquetaRequestDTO request) {
+        Etiqueta entity = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Etiqueta não encontrada, ID:" + id));
+        nameAlreadyExist(entity, request.getNome());
+        mapper.updateEntityFromDTO(request, entity);
+        return mapper.toDto(repository.save(entity));
+    }
+
+    @Override
+    public void deleteEtiqueta(Long id) {
+        findEtiquetaById(id);
+        try {
+            repository.deleteById(id);
+        } catch (DataIntegrityViolationException e) {
+                throw new BusinessException("Não é permitido a exclusão de etiquetas em uso");
+        }
+    }
+
+    @Override
+    @Transactional
+    public EtiquetaResponseDTO updateEtiquetaParcial(Long id, EtiquetaRequestPatchDTO request) {
+        Etiqueta entity = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Etiqueta não encontrada, ID:" + id));
+
+        var nameChange = request.getNome() != null && !request.getNome().equals(entity.getNome());
+
+        if (nameChange) {
+            nameAlreadyExist(entity, request.getNome());
+            entity.setNome(request.getNome());
+        }
+        
+        if (request.getCor() != null) {
+            entity.setCor(request.getCor());
+        }
+
+        return mapper.toDto(repository.save(entity));
+    }
+
+    protected void nameAlreadyExist(Etiqueta entity, String nome){
+        for (Tarefa tarefa : entity.getTarefas()) {
+            boolean exists = repository.existsEtiquetaWithNomeInTarefa(nome, tarefa, entity.getId());
+            if (exists) {
+                throw new BusinessException("Não é possível ter mais de uma Etiqueta com o mesmo nome na tarefa.");
+            }
+        }
+    }
+
+    protected void maxEtiquetas(){
+        int quantidade = repository.countEtiquetas();
+        if (quantidade >= 50) {
+            throw new BusinessException("Limite máximo de Etiquetas alcançados no sistema.");
+        }
+    }
+
+
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
@@ -30,10 +30,12 @@ public class TarefaServiceImpl implements TarefaService {
     private final AnexoMapper anexoMapper;
     private final HistoricoRepository historicoRepository;
     private final HistoricoMapper historicoMapper;
+    private final EtiquetaRepository etiquetaRepository;
 
     public TarefaServiceImpl(TarefaRepository repository, TarefaMapper mapper, ListaRepository listaRepository,
     ComentarioRepository comentarioRepository, ComentarioMapper comentarioMapper, AnexoRepository anexoRepository,
-                             AnexoMapper anexoMapper, HistoricoRepository historicoRepository, HistoricoMapper historicoMapper) {
+                             AnexoMapper anexoMapper, HistoricoRepository historicoRepository, HistoricoMapper historicoMapper,
+                             EtiquetaRepository etiquetaRepository) {
         this.repository = repository;
         this.mapper = mapper;
         this.listaRepository = listaRepository;
@@ -43,6 +45,7 @@ public class TarefaServiceImpl implements TarefaService {
         this.anexoMapper = anexoMapper;
         this.historicoRepository = historicoRepository;
         this.historicoMapper = historicoMapper;
+        this.etiquetaRepository = etiquetaRepository;
     }
 
     @Override
@@ -120,6 +123,54 @@ public class TarefaServiceImpl implements TarefaService {
         return historicos.stream()
                 .map(historicoMapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void addEtiquetaToTarefa(Long idTarefa, List<EtiquetaInsertRequestDTO> request) {
+        Tarefa entity = repository.findById(idTarefa)
+                .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada, id:" + idTarefa));
+
+        if (entity.getEtiquetas().size() + request.size() > 10) {
+            throw new BusinessException("Limite máximo de 10 etiquetas por tarefa alcançado");
+        }
+
+        List<Long> idsEtiquetas = request.stream()
+                .map(EtiquetaInsertRequestDTO::getIdEtiqueta)
+                .toList();
+
+        List<Etiqueta> etiquetas = etiquetaRepository.findAllById(idsEtiquetas);
+
+        if (etiquetas.size() != idsEtiquetas.size()) {
+            throw new ResourceNotFoundException("Uma ou mais etiquetas não foram encontradas.");
+        }
+
+        for (Etiqueta etiqueta : etiquetas) {
+            boolean existsSameName = entity.getEtiquetas().stream()
+                    .anyMatch(e -> e.getNome().equalsIgnoreCase(etiqueta.getNome()));
+            if (existsSameName) {
+                throw new BusinessException("Etiqueta com o nome '" + etiqueta.getNome() + "' já está associada à tarefa");
+            }
+        }
+
+        entity.getEtiquetas().addAll(etiquetas);
+        repository.save(entity);
+    }
+
+    @Override
+    public void removeEtiquetaFromTarefa(Long idTarefa, Long idEtiqueta) {
+        Tarefa entity = repository.findById(idTarefa)
+                .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada, id: " + idTarefa));
+
+        boolean etiquetaExists = entity.getEtiquetas().stream()
+                .anyMatch(etiqueta -> etiqueta.getId().equals(idEtiqueta));
+
+        if (!etiquetaExists) {
+            throw new BusinessException("Etiqueta com ID " + idEtiqueta + " não está associada à tarefa");
+        }
+
+        entity.getEtiquetas().removeIf(etiqueta -> etiqueta.getId().equals(idEtiqueta));
+
+        repository.save(entity);
     }
 
     protected void checkQuantity(Long id){

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
@@ -3,6 +3,7 @@ package com.dev.gabriellucas.taskify.services.impl;
 import com.dev.gabriellucas.taskify.DTO.*;
 import com.dev.gabriellucas.taskify.entities.*;
 import com.dev.gabriellucas.taskify.enums.StatusTarefa;
+import com.dev.gabriellucas.taskify.exceptions.BusinessException;
 import com.dev.gabriellucas.taskify.exceptions.ResourceNotFoundException;
 import com.dev.gabriellucas.taskify.mappers.AnexoMapper;
 import com.dev.gabriellucas.taskify.mappers.ComentarioMapper;
@@ -49,6 +50,7 @@ public class TarefaServiceImpl implements TarefaService {
     public TarefaResponseDTO saveTarefa(TarefaRequestDTO request, Long idLista) {
         Lista lista = listaRepository.findById(idLista)
                 .orElseThrow(() -> new ResourceNotFoundException("Lista não encontrada, id:" + idLista));
+        checkQuantity(idLista);
         Tarefa entity = mapper.toEntity(request);
         entity.setLista(lista);
         return mapper.toDto(repository.save(entity));
@@ -118,6 +120,13 @@ public class TarefaServiceImpl implements TarefaService {
         return historicos.stream()
                 .map(historicoMapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    protected void checkQuantity(Long id){
+        int quantidade = repository.countTarefasByListaId(id);
+        if(quantidade >= 1000){
+            throw new BusinessException("Limite de 1000 tarefas por lista atingido para a lista com ID: " + id);
+        }
     }
 
 


### PR DESCRIPTION
- Criado endpoint para adicionar novas etiquetas à tarefa (`POST /api/tarefas/{id}/etiquetas`).
- Criado endpoint para remover etiquetas de uma tarefa (`DELETE /api/tarefas/{idTarefa}/etiquetas/{idEtiqueta}`).
- Implementadas as lógicas de verificação de limite de etiquetas por tarefa e de associação de etiquetas já existentes.
- Adicionado controle para não permitir a exclusão de etiquetas em uso.
- Implementadas validações para a atualização de etiquetas, incluindo verificações de nome duplicado dentro da tarefa.
- Criação de DTOs para inserção e atualização de etiquetas com validações de entrada.
- Refatoração de métodos de serviço para garantir integridade dos dados e consistência nas operações de associação e remoção de etiquetas.