### PR TITLE
feat: adicionando suporte a anexos com validação de MIME com a lib Apache Tika e Listagem de Etiquetas.

### DIFF
--- a/Back-End/taskify/pom.xml
+++ b/Back-End/taskify/pom.xml
@@ -88,6 +88,11 @@
             <version>1.5.5.Final</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>3.0.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/AnexoResponseDTO.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/DTO/AnexoResponseDTO.java
@@ -1,12 +1,12 @@
 package com.dev.gabriellucas.taskify.DTO;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 public class AnexoResponseDTO {
 
     private Long id;

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/AnexoController.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/AnexoController.java
@@ -1,0 +1,43 @@
+package com.dev.gabriellucas.taskify.controllers;
+
+import com.dev.gabriellucas.taskify.entities.Anexo;
+import com.dev.gabriellucas.taskify.services.AnexoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/anexos")
+@RequiredArgsConstructor
+public class AnexoController {
+
+    private final AnexoService service;
+
+    @GetMapping(value = "/buscar/{id}")
+    public ResponseEntity<Anexo> findByAnexoId(@PathVariable Long id) {
+        Anexo anexoResponseDTO = service.getAnexoById(id);
+        return ResponseEntity.ok().body(anexoResponseDTO);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Resource> download(@PathVariable Long id) throws Exception {
+        Anexo fileUpload = service.getAnexoById(id);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(fileUpload.getTipo()))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "fileUpload; filename=\""+ fileUpload.getNome()
+                        +"\"").body(new ByteArrayResource(fileUpload.getDados()));
+    }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> deleteAnexo(@PathVariable Long id) {
+        service.deleteAnexo(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
@@ -115,4 +115,10 @@ public class TarefaController {
         return ResponseEntity.ok(responseDTO);
     }
 
+    @GetMapping(value = "/{id}/etiquetas")
+    public ResponseEntity<List<EtiquetaResponseDTO>> findAllEtiquetasByTarefaId(@PathVariable Long id) {
+        List<EtiquetaResponseDTO> etiquetaResponseDTO = service.findAllEtiquetasByTarefaId(id);
+        return ResponseEntity.ok().body(etiquetaResponseDTO);
+    }
+
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/controllers/TarefaController.java
@@ -1,22 +1,28 @@
 package com.dev.gabriellucas.taskify.controllers;
 
 import com.dev.gabriellucas.taskify.DTO.*;
+import com.dev.gabriellucas.taskify.entities.Anexo;
+import com.dev.gabriellucas.taskify.services.AnexoService;
 import com.dev.gabriellucas.taskify.services.TarefaService;
 import com.dev.gabriellucas.taskify.services.impl.TarefaServiceImpl;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
 @RequestMapping(value = "/api/tarefas")
 public class TarefaController {
     private final TarefaService service;
+    private final AnexoService anexoService;
 
-    public TarefaController(TarefaService service) {
+    public TarefaController(TarefaService service, AnexoService anexoService) {
         this.service = service;
+        this.anexoService = anexoService;
     }
 
     @PostMapping(value = "/{idLista}")
@@ -88,4 +94,25 @@ public class TarefaController {
         service.removeEtiquetaFromTarefa(idTarefa, idEtiqueta);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping(value = "/{id}/anexos")
+    public ResponseEntity<AnexoResponseDTO> uploadfile(@PathVariable Long id, @RequestParam("file") MultipartFile file) throws IOException {
+        Anexo attachment = null;
+        String downloadUrl = "";
+        attachment = anexoService.saveAnexo(file, id);
+        downloadUrl = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/download/")
+                .path(attachment.getId().toString())
+                .toUriString();
+        AnexoResponseDTO responseDTO = AnexoResponseDTO.builder()
+                .id(attachment.getId())
+                .nome(attachment.getNome())
+                .tipo(attachment.getTipo())
+                .tamanho(attachment.getTamanho())
+                .url(downloadUrl)
+                .build();
+        return ResponseEntity.ok(responseDTO);
+    }
+
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/entities/Anexo.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/entities/Anexo.java
@@ -18,6 +18,9 @@ public class Anexo {
      private Long tamanho;
      private String url;
 
+     @Lob
+     private byte[] dados;
+
      @ManyToOne
      @JoinColumn(name = "tarefa_id", nullable = false)
      private Tarefa tarefa;

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/exceptions/handler/GlobalExceptionHandler.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/exceptions/handler/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -87,6 +88,22 @@ public class GlobalExceptionHandler {
                   .path(httpServletRequest.getRequestURI())
                   .build();
           return ResponseEntity.status(erroResponseDTO.getStatus()).body(erroResponseDTO.toString());
+     }
+
+     @ExceptionHandler(MaxUploadSizeExceededException.class)
+     public ResponseEntity<ErroResponseDTO> handleMaxUploadSizeExceededException(
+             MaxUploadSizeExceededException exception, HttpServletRequest request) {
+
+          ErroResponseDTO erroResponseDTO = ErroResponseDTO.builder()
+                  .timestamp(LocalDateTime.now())
+                  .status(HttpStatus.PAYLOAD_TOO_LARGE.value())
+                  .code(HttpStatus.PAYLOAD_TOO_LARGE.name())
+                  .message("Tamanho máximo de 10MB excedido, tente novamente com um arquivo menor.")
+                  .details("O arquivo enviado excede o limite permitido.")
+                  .path(request.getRequestURI())
+                  .build();
+
+          return ResponseEntity.status(erroResponseDTO.getStatus()).body(erroResponseDTO);
      }
 
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/AnexoRepository.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/AnexoRepository.java
@@ -3,6 +3,8 @@ package com.dev.gabriellucas.taskify.repositories;
 import com.dev.gabriellucas.taskify.entities.Anexo;
 import com.dev.gabriellucas.taskify.entities.Comentario;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +13,6 @@ import java.util.List;
 public interface AnexoRepository extends JpaRepository<Anexo, Long> {
 
     List<Anexo> findAllByTarefaId(Long tarefaId);
+    @Query("SELECT COUNT(t) FROM Anexo t WHERE t.tarefa.id = :id")
+    int countAnexosByTarefaId(@Param("id") Long id);
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/EtiquetaRepository.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/repositories/EtiquetaRepository.java
@@ -1,5 +1,6 @@
 package com.dev.gabriellucas.taskify.repositories;
 
+import com.dev.gabriellucas.taskify.entities.Anexo;
 import com.dev.gabriellucas.taskify.entities.Etiqueta;
 import com.dev.gabriellucas.taskify.entities.Tarefa;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,10 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface EtiquetaRepository extends JpaRepository<Etiqueta, Long> {
     @Query("SELECT COUNT(e) > 0 FROM Etiqueta e WHERE LOWER(e.nome) = LOWER(:nome) AND :tarefa MEMBER OF e.tarefas AND e.id != :id")
     boolean existsEtiquetaWithNomeInTarefa(@Param("nome") String nome, @Param("tarefa") Tarefa tarefa, @Param("id") Long id);
     @Query("SELECT COUNT(e) FROM Etiqueta e")
     int countEtiquetas();
+    List<Etiqueta> findAllByTarefasId(Long tarefaId);
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/AnexoService.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/AnexoService.java
@@ -1,0 +1,14 @@
+package com.dev.gabriellucas.taskify.services;
+
+import com.dev.gabriellucas.taskify.DTO.AnexoResponseDTO;
+import com.dev.gabriellucas.taskify.entities.Anexo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface AnexoService {
+
+    Anexo getAnexoById(Long id);
+    Anexo saveAnexo(MultipartFile file, Long idTarefa) throws IOException;
+    void deleteAnexo(Long id);
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/TarefaService.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/TarefaService.java
@@ -16,4 +16,5 @@ public interface TarefaService {
     List<HistoricoResponseDTO> findAllHistoricosByTarefaId(Long id);
     void addEtiquetaToTarefa(Long idTarefa, List<EtiquetaInsertRequestDTO> request);
     void removeEtiquetaFromTarefa(Long idTarefa, Long idEtiqueta);
+    List<EtiquetaResponseDTO> findAllEtiquetasByTarefaId(Long id);
 }

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/AnexoServiceImpl.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/AnexoServiceImpl.java
@@ -1,0 +1,91 @@
+package com.dev.gabriellucas.taskify.services.impl;
+
+import com.dev.gabriellucas.taskify.entities.Anexo;
+import com.dev.gabriellucas.taskify.entities.Tarefa;
+import com.dev.gabriellucas.taskify.exceptions.BusinessException;
+import com.dev.gabriellucas.taskify.exceptions.ResourceNotFoundException;
+import com.dev.gabriellucas.taskify.repositories.AnexoRepository;
+import com.dev.gabriellucas.taskify.repositories.TarefaRepository;
+import com.dev.gabriellucas.taskify.services.AnexoService;
+import lombok.RequiredArgsConstructor;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AnexoServiceImpl implements AnexoService {
+
+    private final AnexoRepository repository;
+    private final TarefaRepository tarefaRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Anexo getAnexoById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Anexo não encontrado, ID: " + id));
+    }
+
+    @Override
+    @Transactional
+    public Anexo saveAnexo(MultipartFile file, Long idTarefa) throws IOException  {
+
+        if(file.isEmpty()){
+            throw new BusinessException("O arquivo não pode ser vazio");
+        }
+
+        Tarefa tarefa = tarefaRepository.findById(idTarefa)
+                .orElseThrow(() -> new ResourceNotFoundException("Tarefa não encontrada. ID:" + idTarefa));
+
+        maxAnexos(idTarefa);
+        String mime = checkingTypeMime(file);
+
+        Anexo anexo = new Anexo();
+        anexo.setNome(StringUtils.cleanPath(file.getOriginalFilename()));
+        anexo.setTipo(mime);
+        anexo.setTamanho(file.getSize());
+        anexo.setDados(file.getBytes());
+        anexo.setTarefa(tarefa);
+
+        repository.save(anexo);
+
+        String downloadUrl = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/anexos/")
+                .path(anexo.getId().toString())
+                .toUriString();
+
+        anexo.setUrl(downloadUrl);
+
+        return repository.save(anexo);
+    }
+
+    @Override
+    public void deleteAnexo(Long id) {
+        Anexo anexo = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Anexo não encontrado, ID:" + id));
+        repository.deleteById(anexo.getId());
+    }
+
+    protected void maxAnexos(Long idTarefa){
+        int quantidade = repository.countAnexosByTarefaId(idTarefa);
+        if (quantidade >= 10) {
+            throw new BusinessException("Limite máximo de Anexos alcançados na tarefa, ID:" + idTarefa);
+        }
+    }
+
+    protected String checkingTypeMime(MultipartFile file) throws IOException {
+        Tika tika = new Tika();
+        String mime = tika.detect(file.getInputStream());
+        if (mime.equals("application/octet-stream")) {
+            throw new BusinessException("Não é permitido esse tipo de arquivo.");
+        }
+        return mime;
+    }
+
+}

--- a/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
+++ b/Back-End/taskify/src/main/java/com/dev/gabriellucas/taskify/services/impl/TarefaServiceImpl.java
@@ -5,10 +5,7 @@ import com.dev.gabriellucas.taskify.entities.*;
 import com.dev.gabriellucas.taskify.enums.StatusTarefa;
 import com.dev.gabriellucas.taskify.exceptions.BusinessException;
 import com.dev.gabriellucas.taskify.exceptions.ResourceNotFoundException;
-import com.dev.gabriellucas.taskify.mappers.AnexoMapper;
-import com.dev.gabriellucas.taskify.mappers.ComentarioMapper;
-import com.dev.gabriellucas.taskify.mappers.HistoricoMapper;
-import com.dev.gabriellucas.taskify.mappers.TarefaMapper;
+import com.dev.gabriellucas.taskify.mappers.*;
 import com.dev.gabriellucas.taskify.repositories.*;
 import com.dev.gabriellucas.taskify.services.TarefaService;
 import org.springframework.stereotype.Service;
@@ -31,11 +28,12 @@ public class TarefaServiceImpl implements TarefaService {
     private final HistoricoRepository historicoRepository;
     private final HistoricoMapper historicoMapper;
     private final EtiquetaRepository etiquetaRepository;
+    private final EtiquetaMapper etiquetaMapper;
 
     public TarefaServiceImpl(TarefaRepository repository, TarefaMapper mapper, ListaRepository listaRepository,
     ComentarioRepository comentarioRepository, ComentarioMapper comentarioMapper, AnexoRepository anexoRepository,
                              AnexoMapper anexoMapper, HistoricoRepository historicoRepository, HistoricoMapper historicoMapper,
-                             EtiquetaRepository etiquetaRepository) {
+                             EtiquetaRepository etiquetaRepository, EtiquetaMapper etiquetaMapper) {
         this.repository = repository;
         this.mapper = mapper;
         this.listaRepository = listaRepository;
@@ -46,6 +44,7 @@ public class TarefaServiceImpl implements TarefaService {
         this.historicoRepository = historicoRepository;
         this.historicoMapper = historicoMapper;
         this.etiquetaRepository = etiquetaRepository;
+        this.etiquetaMapper = etiquetaMapper;
     }
 
     @Override
@@ -171,6 +170,14 @@ public class TarefaServiceImpl implements TarefaService {
         entity.getEtiquetas().removeIf(etiqueta -> etiqueta.getId().equals(idEtiqueta));
 
         repository.save(entity);
+    }
+
+    @Override
+    public List<EtiquetaResponseDTO> findAllEtiquetasByTarefaId(Long id) {
+        List<Etiqueta> etiquetas = etiquetaRepository.findAllByTarefasId(id);
+        return etiquetas.stream()
+                .map(etiquetaMapper::toDto)
+                .collect(Collectors.toList());
     }
 
     protected void checkQuantity(Long id){

--- a/Back-End/taskify/src/main/resources/db/migration/V1__criar_tabela_anexo.sql
+++ b/Back-End/taskify/src/main/resources/db/migration/V1__criar_tabela_anexo.sql
@@ -5,5 +5,6 @@ CREATE TABLE tb_anexo (
     nome      VARCHAR(255),
     tipo      VARCHAR(255),
     url       VARCHAR(255),
+    dados     MEDIUMBLOB,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB;


### PR DESCRIPTION
- Adicionada a dependência tika-core para validação de MIME

- Criado AnexoController com endpoints para buscar, baixar e excluir anexos

- Adicionado AnexoResponseDTO com suporte a @builder

- Adicionado campo https://github.com/lob private byte[] dados; na entidade Anexo

- Implementado tratamento de exceção para arquivos maiores que 10MB (MaxUploadSizeExceededException)

- Adicionada query countAnexosByTarefaId no AnexoRepository

- Criada interface AnexoService e implementação AnexoServiceImpl

- Métodos auxiliares maxAnexos e checkingTypeMime adicionados

- Uso do Apache Tika para validação de arquivos maliciosos disfarçados de formatos comuns

- Atualização da migration para armazenar anexos (MEDIUMBLOB)

- Adicionada assinatura findAllEtiquetasByTarefaId em TarefaService

- Implementado método em TarefaServiceImpl para buscar etiquetas associadas a uma tarefa

- Adicionada query findAllByTarefasId(Long tarefaId) no EtiquetaRepository

- Criado endpoint GET /{id}/etiquetas em TarefaController para retornar etiquetas de uma tarefa
